### PR TITLE
refactor DuckDB query into a shared API module

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -26,6 +26,7 @@
             "elm-community/typed-svg": "7.0.0",
             "gicentre/elm-vegalite": "5.0.0",
             "ianmackenzie/elm-3d-scene": "1.0.1",
+            "jweir/elm-iso8601": "7.0.1",
             "krisajenkins/remotedata": "6.0.1",
             "mdgriffith/elm-ui": "1.1.8",
             "norpan/elm-html5-drag-drop": "3.1.4",
@@ -34,6 +35,7 @@
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "elm-explorations/linear-algebra": "1.0.3",
             "elm-explorations/webgl": "1.1.3",

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -1,5 +1,11 @@
 module Api exposing (..)
 
+import Config exposing (apiHost)
+import Http exposing (Error(..))
+import Json.Decode as JD
+import Json.Encode as JE
+import RemoteData exposing (RemoteData, asCmd)
+
 
 type alias Column =
     { name : String
@@ -39,3 +45,84 @@ type alias DuckDbMetaResponse =
 type alias DuckDbTableRefsResponse =
     { refs : List TableRef
     }
+
+
+queryDuckDb : String -> Bool -> List TableRef -> (Result Error DuckDbQueryResponse -> msg) -> Cmd msg
+queryDuckDb query allowFallback refs onResponse =
+    let
+        duckDbQueryEncoder : JE.Value
+        duckDbQueryEncoder =
+            JE.object
+                [ ( "query_str", JE.string query )
+                , ( "allow_blob_fallback", JE.bool allowFallback )
+                , ( "fallback_table_refs", JE.list JE.string refs )
+                ]
+
+        duckDbQueryResponseDecoder : JD.Decoder DuckDbQueryResponse
+        duckDbQueryResponseDecoder =
+            let
+                columnDecoderHelper : JD.Decoder Column
+                columnDecoderHelper =
+                    JD.field "type" JD.string |> JD.andThen decoderByType
+
+                decoderByType : String -> JD.Decoder Column
+                decoderByType type_ =
+                    case type_ of
+                        "VARCHAR" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Varchar_ JD.string))))
+
+                        "INTEGER" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Int_ JD.int))))
+
+                        "BIGINT" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Int_ JD.int))))
+
+                        "BOOLEAN" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Bool_ JD.bool))))
+
+                        "DOUBLE" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Float_ JD.float))))
+
+                        "DATE" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Varchar_ JD.string))))
+
+                        "TIMESTAMP" ->
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.field "values" (JD.list (JD.maybe (JD.map Varchar_ JD.string))))
+
+                        _ ->
+                            -- This feels wrong to me, but unsure how else to workaround the string pattern matching
+                            -- Should this fail loudly?
+                            JD.map3 Column
+                                (JD.field "name" JD.string)
+                                (JD.field "type" JD.string)
+                                (JD.list (JD.maybe (JD.succeed Unknown)))
+            in
+            JD.map DuckDbQueryResponse
+                (JD.field "columns" (JD.list columnDecoderHelper))
+    in
+    Http.post
+        { url = apiHost ++ "/duckdb"
+        , body = Http.jsonBody duckDbQueryEncoder
+        , expect = Http.expectJson onResponse duckDbQueryResponseDecoder
+        }

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -20,6 +20,7 @@ import Gen.Params.Sheet exposing (Params)
 import Html as H
 import Html.Attributes as HA
 import Http exposing (Error(..))
+import ISO8601 as Iso
 import Json.Decode as JD
 import Json.Encode as JE
 import List.Extra as LE
@@ -194,6 +195,9 @@ cell2Str cd =
             else
                 ( s, "String" )
 
+        Time_ t ->
+            ( Iso.toString t, "Time" )
+
         Float_ f ->
             ( String.fromFloat f, "Float" )
 
@@ -306,6 +310,9 @@ mapColumnsToSheet cols =
 
                         Api.Int_ i ->
                             Int_ i
+
+                        Api.Time_ t ->
+                            Time_ t
 
                         Api.Bool_ b ->
                             Bool_ b
@@ -830,6 +837,9 @@ viewDataInspectPanel model =
                                             centerX
 
                                         String_ _ ->
+                                            alignLeft
+
+                                        Time_ _ ->
                                             alignLeft
 
                                         Bool_ _ ->

--- a/src/Pages/VegaLite.elm
+++ b/src/Pages/VegaLite.elm
@@ -1,6 +1,6 @@
 module Pages.VegaLite exposing (Model, Msg, page)
 
-import Api
+import Api exposing (queryDuckDb)
 import Array
 import Config exposing (apiHost)
 import Dict exposing (Dict)
@@ -99,7 +99,7 @@ type Msg
     | RenderPlot
     | FetchTableRefs
     | FetchMetaDataForRef Api.TableRef
-    | GotDuckDbForPlotResponse (Result Http.Error Api.DuckDbQueryResponse)
+    | GotDuckDbResponse (Result Http.Error Api.DuckDbQueryResponse)
     | GotDuckDbMetaResponse (Result Http.Error Api.DuckDbMetaResponse)
     | GotDuckDbTableRefsResponse (Result Http.Error Api.DuckDbTableRefsResponse)
     | UserSelectedTableRef Api.TableRef
@@ -196,9 +196,9 @@ order by 1
 limit 100
                 """
             in
-            ( model, Effect.fromCmd <| queryDuckDbForPlot queryStr True [ "elm_test_1657972702341" ] )
+            ( model, Effect.fromCmd <| queryDuckDb queryStr True [ "elm_test_1657972702341" ] GotDuckDbResponse )
 
-        GotDuckDbForPlotResponse response ->
+        GotDuckDbResponse response ->
             case response of
                 Ok data ->
                     ( { model
@@ -480,19 +480,12 @@ viewColumnPickerPanel model =
                         (\c ->
                             case mapToKimball c of
                                 KimballColumn_ ( colRef, kc ) ->
-                                    if
-                                        List.member kc
-                                            [ Measure Sum
-                                            , Measure Mean
-                                            , Measure Median
-                                            , Measure Min
-                                            , Measure Max
-                                            ]
-                                    then
-                                        Just <| KimballColumn_ ( colRef, kc )
+                                    case kc of
+                                        Measure _ ->
+                                            Just <| KimballColumn_ ( colRef, kc )
 
-                                    else
-                                        Nothing
+                                        _ ->
+                                            Nothing
                         )
                         cols
 
@@ -502,11 +495,12 @@ viewColumnPickerPanel model =
                         (\c ->
                             case mapToKimball c of
                                 KimballColumn_ ( colRef, kc ) ->
-                                    if kc == Error then
-                                        Just <| KimballColumn_ ( colRef, kc )
+                                    case kc of
+                                        Error ->
+                                            Just <| KimballColumn_ ( colRef, kc )
 
-                                    else
-                                        Nothing
+                                        _ ->
+                                            Nothing
                         )
                         cols
             in
@@ -795,79 +789,7 @@ computeSpec model =
 
 
 -- end region vega-lite
--- begin region query building
--- end region query building
 -- begin region API
-
-
-queryDuckDbForPlot : String -> Bool -> List Api.TableRef -> Cmd Msg
-queryDuckDbForPlot query allowFallback refs =
-    let
-        duckDbQueryEncoder : JE.Value
-        duckDbQueryEncoder =
-            JE.object
-                [ ( "query_str", JE.string query )
-                , ( "allow_blob_fallback", JE.bool allowFallback )
-                , ( "fallback_table_refs", JE.list JE.string refs )
-                ]
-
-        duckDbQueryResponseDecoder : JD.Decoder Api.DuckDbQueryResponse
-        duckDbQueryResponseDecoder =
-            let
-                columnDecoderHelper : JD.Decoder Api.Column
-                columnDecoderHelper =
-                    JD.field "type" JD.string |> JD.andThen decoderByType
-
-                decoderByType : String -> JD.Decoder Api.Column
-                decoderByType type_ =
-                    case type_ of
-                        "VARCHAR" ->
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.field "values" (JD.list (JD.maybe (JD.map Api.Varchar_ JD.string))))
-
-                        "INTEGER" ->
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.field "values" (JD.list (JD.maybe (JD.map Api.Int_ JD.int))))
-
-                        "BOOLEAN" ->
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.field "values" (JD.list (JD.maybe (JD.map Api.Bool_ JD.bool))))
-
-                        "DOUBLE" ->
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.field "values" (JD.list (JD.maybe (JD.map Api.Float_ JD.float))))
-
-                        "DATE" ->
-                            -- TODO: Need to think about Elm date / time types
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.field "values" (JD.list (JD.maybe (JD.map Api.Varchar_ JD.string))))
-
-                        _ ->
-                            -- This feels wrong to me, but unsure how else to workaround the string pattern matching
-                            -- Should this fail loudly?
-                            JD.map3 Api.Column
-                                (JD.field "name" JD.string)
-                                (JD.field "type" JD.string)
-                                (JD.list (JD.maybe (JD.succeed Api.Unknown)))
-            in
-            JD.map Api.DuckDbQueryResponse
-                (JD.field "columns" (JD.list columnDecoderHelper))
-    in
-    Http.post
-        { url = apiHost ++ "/duckdb"
-        , body = Http.jsonBody duckDbQueryEncoder
-        , expect = Http.expectJson GotDuckDbForPlotResponse duckDbQueryResponseDecoder
-        }
 
 
 queryDuckDbMeta : String -> Bool -> List Api.TableRef -> Cmd Msg

--- a/src/Pages/VegaLite.elm
+++ b/src/Pages/VegaLite.elm
@@ -382,10 +382,16 @@ mapToKimball colDesc =
                 "DATE" ->
                     Time
 
+                "TIMESTAMP" ->
+                    Time
+
                 "BOOLEAN" ->
                     Dimension
 
                 "INTEGER" ->
+                    Measure Sum
+
+                "BIGINT" ->
                     Measure Sum
 
                 "DOUBLE" ->

--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -33,11 +33,14 @@ kimballClassificationToString kc =
 
 
 type Aggregation
-    = Sum
+    = Unspecified
+    | Sum
     | Mean
     | Median
     | Min
     | Max
+    | Count
+    | CountDistinct
 
 
 type alias SqlStr =

--- a/src/SheetModel.elm
+++ b/src/SheetModel.elm
@@ -3,6 +3,7 @@ module SheetModel exposing (..)
 import Array as A
 import Array.Extra as AE
 import Array2D exposing (Array2D, ColIx, RowIx)
+import ISO8601 as Iso
 
 
 
@@ -12,6 +13,7 @@ import Array2D exposing (Array2D, ColIx, RowIx)
 type CellElement
     = Empty
     | String_ String
+    | Time_ Iso.Time
     | Float_ Float
     | Int_ Int
     | Bool_ Bool


### PR DESCRIPTION
 * Modularize "main" DuckDB endpoint
 * treat time values as time values, not strings, in both sheet and vega-lite pages