### PR TITLE
introduce time class

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -5,19 +5,20 @@ import Http exposing (Error(..))
 import ISO8601 as Iso
 import Json.Decode as JD
 import Json.Encode as JE
+import QueryBuilder exposing (ColumnRef)
 import RemoteData exposing (RemoteData, asCmd)
 import Url exposing (fromString)
 
 
 type alias Column =
-    { name : String
+    { ref : ColumnRef
     , type_ : String
     , vals : List (Maybe Val)
     }
 
 
 type alias ColumnDescription =
-    { name : String
+    { ref : ColumnRef
     , type_ : String
     }
 

--- a/src/Pages/Sheet.elm
+++ b/src/Pages/Sheet.elm
@@ -332,7 +332,7 @@ mapColumnsToSheet cols =
             LE.transpose lolWrong
 
         colLabels =
-            List.map (\col -> col.name) cols
+            List.map (\col -> col.ref) cols
     in
     array2DToSheet (fromListOfLists lolTransposed) colLabels
 

--- a/src/Pages/VegaLite.elm
+++ b/src/Pages/VegaLite.elm
@@ -818,13 +818,13 @@ computeSpec model =
             let
                 data =
                     VL.dataFromColumns []
-                        << VL.dataColumn col1.name (VL.nums (List.map (\i -> toFloat i) col1.vals))
-                        << VL.dataColumn col2.name (VL.nums col2.vals)
+                        << VL.dataColumn col1.ref (VL.nums (List.map (\i -> toFloat i) col1.vals))
+                        << VL.dataColumn col2.ref (VL.nums col2.vals)
 
                 enc =
                     VL.encoding
-                        << VL.position VL.X [ VL.pName col1.name, VL.pQuant ]
-                        << VL.position VL.Y [ VL.pName col2.name, VL.pQuant ]
+                        << VL.position VL.X [ VL.pName col1.ref, VL.pQuant ]
+                        << VL.position VL.Y [ VL.pName col2.ref, VL.pQuant ]
             in
             VL.toVegaLite
                 [ data []
@@ -852,7 +852,7 @@ computeSpec model =
                 col1 =
                     case Array.get 0 collArray of
                         Nothing ->
-                            { name = "error"
+                            { ref = "error"
                             , vals = []
                             }
 
@@ -862,7 +862,7 @@ computeSpec model =
                 col2 =
                     case Array.get 1 collArray of
                         Nothing ->
-                            { name = "error"
+                            { ref = "error"
                             , vals = []
                             }
 

--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -73,6 +73,32 @@ queryBuilder kCols tRef =
                         Dimension colRef ->
                             Just colRef
 
+                        Time timeClass colRef ->
+                            case timeClass of
+                                Continuous ->
+                                    Just colRef
+
+                                Discrete Year ->
+                                    Just <| "date_trunc('year', " ++ colRef ++ ")"
+
+                                Discrete Quarter ->
+                                    Just <| "date_trunc('quarter', " ++ colRef ++ ")"
+
+                                Discrete Month ->
+                                    Just <| "date_trunc('month', " ++ colRef ++ ")"
+
+                                Discrete Week ->
+                                    Just <| "date_trunc('week', " ++ colRef ++ ")"
+
+                                Discrete Day ->
+                                    Just <| "date_trunc('day', " ++ colRef ++ ")"
+
+                                Discrete Hour ->
+                                    Just <| "date_trunc('hour', " ++ colRef ++ ")"
+
+                                Discrete Minute ->
+                                    Just <| "date_trunc('minute', " ++ colRef ++ ")"
+
                         _ ->
                             Nothing
                 )
@@ -91,4 +117,4 @@ queryBuilder kCols tRef =
                 )
                 kCols
     in
-    "select " ++ String.join "," selectFields ++ "," ++ String.join "," groupByFields ++ " from " ++ tRef
+    "select " ++ String.join "," selectFields ++ String.join "," groupByFields ++ " from " ++ tRef

--- a/src/VegaUtils.elm
+++ b/src/VegaUtils.elm
@@ -5,7 +5,7 @@ import Utils exposing (removeNothingsFromList)
 
 
 type alias ColumnParamed val =
-    { name : String
+    { ref : String
     , vals : List val
     }
 
@@ -30,12 +30,12 @@ mapColToStringCol col =
                         _ ->
                             []
             in
-            { name = col.ref
+            { ref = col.ref
             , vals = mapToStringList [] vals_
             }
 
         _ ->
-            { name = "ERROR - STRING MAP"
+            { ref = "ERROR - STRING MAP"
             , vals = []
             }
 
@@ -60,12 +60,12 @@ mapColToFloatCol col =
                         _ ->
                             []
             in
-            { name = col.ref
+            { ref = col.ref
             , vals = mapToFloatList [] vals_
             }
 
         _ ->
-            { name = "ERROR - FLOAT MAP"
+            { ref = "ERROR - FLOAT MAP"
             , vals = []
             }
 
@@ -90,11 +90,11 @@ mapColToIntegerCol col =
                         _ ->
                             []
             in
-            { name = col.ref
+            { ref = col.ref
             , vals = mapToIntList [] vals_
             }
 
         _ ->
-            { name = "ERROR - INT MAP"
+            { ref = "ERROR - INT MAP"
             , vals = []
             }

--- a/src/VegaUtils.elm
+++ b/src/VegaUtils.elm
@@ -30,7 +30,7 @@ mapColToStringCol col =
                         _ ->
                             []
             in
-            { name = col.name
+            { name = col.ref
             , vals = mapToStringList [] vals_
             }
 
@@ -60,7 +60,7 @@ mapColToFloatCol col =
                         _ ->
                             []
             in
-            { name = col.name
+            { name = col.ref
             , vals = mapToFloatList [] vals_
             }
 
@@ -90,7 +90,7 @@ mapColToIntegerCol col =
                         _ ->
                             []
             in
-            { name = col.name
+            { name = col.ref
             , vals = mapToIntList [] vals_
             }
 

--- a/tests/VegaUtilsTest.elm
+++ b/tests/VegaUtilsTest.elm
@@ -30,8 +30,9 @@ suite =
         ]
 
 
+stringColumn : Column
 stringColumn =
-    { name = "a string column"
+    { ref = "a string column"
     , type_ = "VARCHAR"
     , vals =
         [ Just (Varchar_ "one")
@@ -43,13 +44,14 @@ stringColumn =
 
 colParamedString : ColumnParamed String
 colParamedString =
-    { name = "a string column"
+    { ref = "a string column"
     , vals = [ "one", "two", "three" ]
     }
 
 
+integerColumn : Column
 integerColumn =
-    { name = "an int column"
+    { ref = "an int column"
     , type_ = "INTEGER"
     , vals =
         [ Just (Int_ 1)
@@ -61,13 +63,14 @@ integerColumn =
 
 colParamedInt : ColumnParamed Int
 colParamedInt =
-    { name = "an int column"
+    { ref = "an int column"
     , vals = [ 1, 2, 3 ]
     }
 
 
+floatColumn : Column
 floatColumn =
-    { name = "a float column"
+    { ref = "a float column"
     , type_ = "DOUBLE"
     , vals =
         [ Just (Float_ 3.1)
@@ -79,6 +82,6 @@ floatColumn =
 
 colParamedFloat : ColumnParamed Float
 colParamedFloat =
-    { name = "a float column"
+    { ref = "a float column"
     , vals = [ 3.1, 3.14, 3.2 ]
     }


### PR DESCRIPTION
Introduces TimeClass with variants inspired by Tableau's user-experience. Continuous, or discrete with a defined granularity. SQL queries are then built with the appropriate DuckDB timestamp transformation function.

I've left out the vega-lite spec building here, as I don't yet have complete information on the rest of the plot. I'll return to this after finishing the measure / aggregations query building.