### PR TITLE
UI - measure dropdown, dimension coloring

### DIFF
--- a/src/QueryBuilder.elm
+++ b/src/QueryBuilder.elm
@@ -174,3 +174,28 @@ queryBuilder kCols tRef =
             ++ groupBys
         )
         True
+
+
+aggToStr : Aggregation -> String
+aggToStr agg =
+    case agg of
+        Sum ->
+            "sum"
+
+        Mean ->
+            "mean"
+
+        Median ->
+            "median"
+
+        Min ->
+            "min"
+
+        Max ->
+            "max"
+
+        Count ->
+            "count"
+
+        CountDistinct ->
+            "count (distinct)"


### PR DESCRIPTION
 * Adds dropdown for measure tabs, allowing the user to change aggregation types.
 * solves UI bug with overlapping dropdown menus
 * selected dimension render tab with blue background

<img width="104" alt="image" src="https://user-images.githubusercontent.com/993431/186138402-765abd06-25f1-43ed-ad6b-1d7a1b9ff926.png">
